### PR TITLE
feat: color customization

### DIFF
--- a/qtile/.config/qtile/ColorScheme.py
+++ b/qtile/.config/qtile/ColorScheme.py
@@ -1,0 +1,113 @@
+import requests
+
+
+class ColorScheme:
+    """
+    Should foreground and background be added separately?
+    Color labels MIGHT be inaccurate in some cases.
+    TODO: change colors with a shell script where theme name is provided.
+    
+    Initializes a color scheme with defaults:
+    black = '353535'
+    red = 'D25252'
+    green = 'A5C261'
+    yellow = 'FFC66D'
+    blue = '6C99BB'
+    magenta = 'D197D9'
+    cyan = 'BED6FF'
+    white = 'EEEEEC'
+    bright_black = '535353'
+    bright_red = 'F00C0C'
+    bright_green = 'C2E075'
+    bright_yellow = 'E1E48B'
+    bright_blue = '8AB7D9'
+    bright_magenta = 'EFB5F7'
+    bright_cyan = 'DCF4FF'
+    bright_white = 'FFFFFF'
+
+    This particular default scheme is "Espresso" from https://gogh-co.github.io/Gogh/
+
+    Set your theme with `set_colors_from_dict(color_dict)` or `set_colors_from_theme(theme_name)`
+    Get available themes with `get_all_themes()`
+    Get current scheme with `get_current_scheme()`
+    """
+
+    ALL_COLORS = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'bright_black',
+                  'bright_red', 'bright_green', 'bright_yellow', 'bright_blue', 'bright_magenta', 'bright_cyan', 'bright_white']
+    JSON_URL = 'https://raw.githubusercontent.com/Gogh-Co/Gogh/master/data/themes.json'
+
+    def __init__(self):
+        self.black = '353535'
+        self.red = 'D25252'
+        self.green = 'A5C261'
+        self.yellow = 'FFC66D'
+        self.blue = '6C99BB'
+        self.magenta = 'D197D9'
+        self.cyan = 'BED6FF'
+        self.white = 'EEEEEC'
+        self.bright_black = '535353'
+        self.bright_red = 'F00C0C'
+        self.bright_green = 'C2E075'
+        self.bright_yellow = 'E1E48B'
+        self.bright_blue = '8AB7D9'
+        self.bright_magenta = 'EFB5F7'
+        self.bright_cyan = 'DCF4FF'
+        self.bright_white = 'FFFFFF'
+
+    def set_colors_from_dict(self, color_dict: dict) -> None:
+        """
+        Pass in a dictionary with colors you want to set for the following:
+        black, red, green, yellow, blue, magenta, cyan, white, bright_black, bright_red, bright_green, bright_yellow, bright_blue, bright_magenta, bright_cyan, bright_white
+
+        There is no proper validation for hex values yet.
+        """
+        for color_name, value in color_dict.items():
+            color_name = '_'.join(color_name.split('-'))
+            value = value[1:] if value[0] == '#' else value
+
+            if hasattr(self, color_name):
+                setattr(self, color_name, value)
+            else:
+                raise ValueError(
+                    f"Error: Color '{color_name}' not found in ColorScheme."
+                )
+
+    def set_colors_from_theme(self, theme_name: str) -> None:
+        """
+        Pass in an existing theme_name from https://gogh-co.github.io/Gogh/
+        Colors are extracted from https://raw.githubusercontent.com/Gogh-Co/Gogh/master/data/themes.json
+        Use `get_all_themes()` to get all theme names. 
+        """
+        all_themes = ColorScheme.__get_json_data()
+        theme = next((theme for theme in all_themes if theme["name"] == theme_name), None)
+        if theme:
+            index = 0
+            for key, value in theme.items():
+                if key[:6] == 'color_':
+                    setattr(self, ColorScheme.ALL_COLORS[index], value[1:])
+                    index += 1
+        else:
+            raise ValueError(
+                f"Error: Theme '{theme_name}' not found in Gogh."
+            )
+
+    def __get_json_data() -> list:
+        """
+        Returns a list with all the themes from Gogh.
+        """
+        r = requests.get(url=ColorScheme.JSON_URL)
+        return r.json()
+
+    def get_all_themes(self) -> set:
+        """
+        Returns a list of all existing themes.
+        """
+        # Needs optimization. Maybe download the json and store locally and periodically check for new themes?
+        all_themes = ColorScheme.__get_json_data()
+        return {theme['name'] for theme in all_themes}
+
+    def get_current_scheme(self) -> dict:
+        """
+        Returns a dictionary of currently set color_scheme.
+        """
+        return {color_name: getattr(self, color_name) for color_name in ColorScheme.ALL_COLORS}

--- a/qtile/.config/qtile/config.py
+++ b/qtile/.config/qtile/config.py
@@ -8,6 +8,14 @@ from spotify import Spotify
 
 import subprocess
 
+from ColorScheme import ColorScheme
+your_theme_name = "Lunaria Eclipse"
+CS = ColorScheme()
+try:
+    CS.set_colors_from_theme(your_theme_name)
+except Exception as e:
+    CS = ColorScheme()
+
 mod = "mod4"
 terminal = "kitty"
 
@@ -217,6 +225,7 @@ widget_defaults = dict(
 )
 extension_defaults = widget_defaults.copy()
 
+BAR_BG = CS.black
 screens = [
     Screen(
         wallpaper=walp,
@@ -224,7 +233,7 @@ screens = [
         top=bar.Bar(
             [
                 widget.Image(
-                    background="11111bbf",
+                    background=BAR_BG,
                     filename=logo,
                     margin=5
                 ),
@@ -237,12 +246,12 @@ screens = [
                     borderwidth=5,
                     active="bac2de",
                     inactive="6c7086",
-                    background="11111bbf",
+                    background=BAR_BG,
                     disable_drag=False,
                     font="CaskaydiaCove Nerd Font Mono",
                     highlight_method="line",
                     highlight_color="181825cc",
-                    this_current_screen_border="cba6f7"
+                    this_current_screen_border=CS.bright_cyan
                 ),
                 widget.TaskList(
                     urgent_alert_method="text",
@@ -263,12 +272,12 @@ screens = [
                     pause_icon="󰽰",
                     format="{icon} {artist} - {track}",
                     font="CaskaydiaCove Nerd Font Mono Italic",
-                    background="cba6f7bf",
+                    background=CS.cyan,
                     foreground="161320",
                 ),
                 widget.Battery(
                     foreground="161320",
-                    background="a6e3a1bf",
+                    background=CS.green,
                     low_background="F28FAD",
                     low_foreground="161320",
                     low_percentage=0.2,
@@ -279,35 +288,35 @@ screens = [
                 ),
                 widget.Volume(
                     fmt='󰕾 {}',
-                    background="94e2d5bf",
+                    background=CS.blue,
                     foreground="161320"
                 ),
                 widget.Clock(
                     format="%dth %b, %Y",
                     foreground="161320",
-                    background="74c7ecbf"
+                    background=CS.magenta
                 ),
                 widget.Clock(
                     format="%I:%M %p",
                     foreground="161320",
-                    background="f9e2afbf"
+                    background=CS.bright_magenta
                 ),
                 widget.Systray(
                     background="89b4fa00"
                 ),
                 widget.Sep(
                     foreground="302D4100",
-                    background="302D4100",
+                    background=CS.white,
                     padding=5
                 ),
                 widget.QuickExit(
                     fmt="[X]",
                     foreground="161320",
-                    background="f38ba8bf"
+                    background=CS.red
                 ),
             ],
             30,
-            background="11111bbf",
+            background=CS.white,
         ),
     ),
 ]


### PR DESCRIPTION
qtile/config.py now has a new instance of ColorScheme class. Color schemes from [Gogh](https://gogh-co.github.io/Gogh/) are used. Pass in the name of a theme to from Gogh to see it in action.